### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .DS_Store
 tags
 config/app.php
+logs/*
+webroot/error_log
+tmp/*


### PR DESCRIPTION
Don’t include logs, tmp or error_log
