### PR TITLE
Fixed flash elements and help

### DIFF
--- a/plugins/SiteManager/src/Template/Element/help.ctp
+++ b/plugins/SiteManager/src/Template/Element/help.ctp
@@ -1,15 +1,15 @@
-<?php 
+<?php
 	use Cake\Utility\Inflector;
-	
+
 	/* ELEMENT HELP */
-	
+
 	// REQUIRED VARIABLES
 	if(!isset($element)) $element = 'no';
 	if(!isset($options)) $options = null;
 ?>
 <h3>Element Help - <strong><?= Inflector::humanize($element) ?></strong></h3>
 <p class="lead">Usage</p>
-<pre>echo $this->element('Bootstrap/<?= $element ?>', ['option' => 'value', 'option2' => 'value2']);</pre>
+<pre>echo $this->element('SiteManager.Bootstrap/<?= $element ?>', ['option' => 'value', 'option2' => 'value2']);</pre>
 <?php if($options != null):?>
 <p class="lead">Options</p>
 <table class="table table-bordered table-condensed">

--- a/src/Template/Element/Flash/default.ctp
+++ b/src/Template/Element/Flash/default.ctp
@@ -4,4 +4,4 @@ if (!empty($params['class'])) {
     $class = $params['class'];
 }
 ?>
-<?= $this->element('Bootstrap/alert',['class' => $class, 'message' => h($message), 'dismissible' => true]); ?>
+<?= $this->element('SiteManager.Bootstrap/alert',['class' => $class, 'message' => h($message), 'dismissible' => true]); ?>

--- a/src/Template/Element/Flash/error.ctp
+++ b/src/Template/Element/Flash/error.ctp
@@ -1,1 +1,1 @@
-<?= $this->element('Bootstrap/alert',['class' => 'danger', 'title' => $this->element('Bootstrap/icon', ['icon' => 'alert']) .' Ooops', 'message' => h($message), 'dismissible' => true]); ?>
+<?= $this->element('SiteManager.Bootstrap/alert',['class' => 'danger', 'title' => $this->element('SiteManager.Bootstrap/icon', ['icon' => 'alert']) .' Ooops', 'message' => h($message), 'dismissible' => true]); ?>

--- a/src/Template/Element/Flash/success.ctp
+++ b/src/Template/Element/Flash/success.ctp
@@ -1,1 +1,1 @@
-<?= $this->element('Bootstrap/alert',['class' => 'success', 'title' => $this->element('Bootstrap/icon', ['icon' => 'thumbs-up']) .' Yay!', 'message' => h($message), 'dismissible' => true]); ?>
+<?= $this->element('SiteManager.Bootstrap/alert',['class' => 'success', 'title' => $this->element('SiteManager.Bootstrap/icon', ['icon' => 'thumbs-up']) .' Yay!', 'message' => h($message), 'dismissible' => true]); ?>


### PR DESCRIPTION
Help was pointing to the wrong location for the example and the flash
alerts were not pointing to the plugin.
