### PR TITLE
Fix Navbar Active for Production

### DIFF
--- a/plugins/SiteManager/src/Template/Element/Bootstrap/navbar.ctp
+++ b/plugins/SiteManager/src/Template/Element/Bootstrap/navbar.ctp
@@ -73,7 +73,7 @@ use Cake\View\HelperRegistry;
 										// CHECK ACTIVE LINK LOGIC
 										$active = '';
 										// HOME BUTTON
-										if(($link == '/') && ($this->request->here == '/')) $active = ' class="active"';
+										if(($link == '/') && ($this->request->here == '/') || ($this->request->here == '/production/')) $active = ' class="active"';
 										// OTHER
 										if(($link != '/') && (strpos($this->request->here, $link) !== false)) $active = ' class="active"';
 									?>


### PR DESCRIPTION
Production home link wasn’t showing active because the site is
redirected from the .htaccess at the top level.
