### PR TITLE
Fixed carousel image title

### DIFF
--- a/plugins/SiteManager/src/Template/Element/Bootstrap/carousel.ctp
+++ b/plugins/SiteManager/src/Template/Element/Bootstrap/carousel.ctp
@@ -37,7 +37,7 @@
 			<div class="item<?php if($num == 0) echo ' active' ?>">
 				<img src="/img/<?= $image['path'] ?>"<?php if(!empty($image['alt'])) echo ' alt="'. $image['alt'] .'"'; ?>>
 				<div class="carousel-caption">
-					<?php if($image['title']): ?>
+					<?php if(!empty($image['title'])): ?>
 						<h3><?= $image['title'] ?></h3>
 					<?php endif; ?>
 					<p><?= $image['caption'] ?></p>


### PR DESCRIPTION
If the title was not being passed, a null reference was being accessed.
Instead of checking for true or false it now does if(!empty()) which
will only be true if the title is set to something other than false or
null. #46
